### PR TITLE
Fix "expected `i8`, found `bool`" for x86_64-apple-darwin target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,16 @@ on:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
     name: Test Suite
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -17,4 +25,4 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --all-features --workspace ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --all-features --workspace ${{ matrix.args }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ version = "0.0.3"
 dependencies = [
  "avfaudio2-sys",
  "block",
+ "objc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ name = "session"
 [dependencies]
 avfaudio2-sys = "0.2.4"
 block = "0.1.6"
+objc = "0.2.7"

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,6 +6,8 @@ use avfaudio2_sys::{
     IAVAudioSession, NSError,
 };
 
+use objc::runtime::{NO, YES};
+
 #[doc = "Audio session category identifiers."]
 #[doc = "https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory"]
 pub struct Category(AVAudioSessionCategory);
@@ -91,7 +93,7 @@ impl AVAudioSession {
             #[allow(unused)]
             let mut error: *mut NSError = ::std::ptr::null_mut();
 
-            unsafe { session.setActive_error_(true, error) };
+            unsafe { session.setActive_error_(YES, error) };
         }
     }
 
@@ -101,7 +103,7 @@ impl AVAudioSession {
             #[allow(unused)]
             let mut error: *mut NSError = ::std::ptr::null_mut();
 
-            unsafe { session.setActive_error_(false, error) };
+            unsafe { session.setActive_error_(NO, error) };
         }
     }
 }


### PR DESCRIPTION
Hello, so the problem is that if you try to run test for x86_64-apple-darwin target
```sh
cargo test --all-features --workspace --target x86_64-apple-darwin
```
you got an error
```
error[E0308]: mismatched types
      --> src/session.rs:94:47
       |
94     |             unsafe { session.setActive_error_(true, error) };
       |                              ---------------- ^^^^ expected `i8`, found `bool`
       |                              |
       |                              arguments to this method are incorrect
       |
note: method defined here
      --> /Users/fp/code/github.com/fullpipe/avfaudio-rs/target/x86_64-apple-darwin/debug/build/avfaudio2-sys-2067e0b2236ab6d4/out/bindings.rs:284836:15
       |
284836 |     unsafe fn setActive_error_(&self, active: BOOL, outError: *mut NSError) -> BOOL
       |               ^^^^^^^^^^^^^^^^
...
```

as i understand for `x86_64` `BOOL` is `c_schar` and defined as
```rust
pub type BOOL = ::std::os::raw::c_schar;
```

for aarch64 `BOOL` is `bool`
```rust
pub type BOOL = bool;
```

and use of `use objc::runtime::{NO, YES};` fixes the proplem

Fixes #2 